### PR TITLE
alsa: Fix inclusion of use-case.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -824,7 +824,7 @@ AS_IF([test "x$enable_alsa" = "xyes" && test "x$HAVE_ALSA" = "x0"],
 AS_IF([test "x$HAVE_ALSA" = "x1"],
     [
         save_CPPFLAGS="$CPPFLAGS"; CPPFLAGS="$CPPFLAGS $ASOUNDLIB_CFLAGS"
-        AC_CHECK_HEADERS([use-case.h], HAVE_ALSA_UCM=1, HAVE_ALSA_UCM=0)
+        AC_CHECK_HEADERS([alsa/use-case.h], HAVE_ALSA_UCM=1, HAVE_ALSA_UCM=0)
         CPPFLAGS="$save_CPPFLAGS"
     ],
     HAVE_ALSA_UCM=0)

--- a/src/modules/alsa/alsa-ucm.h
+++ b/src/modules/alsa/alsa-ucm.h
@@ -23,7 +23,7 @@
 ***/
 
 #ifdef HAVE_ALSA_UCM
-#include <use-case.h>
+#include <alsa/use-case.h>
 #else
 typedef void snd_use_case_mgr_t;
 #endif


### PR DESCRIPTION
alsa: Fix inclusion of use-case.h

The recent change in ALSA upstream stripped -I$include/alsa path from
pkgconfig.  We already fixed for this change in some places but still
the code for UCM was overlooked, and this resulted in the unresolved
symbols in alsa card module. Fix them as well.
Signed-off-by: Takashi Iwai's avatarTakashi Iwai <tiwai@suse.de>